### PR TITLE
Remove unused jcl-over-slf4j dependency from ph-httpclient

### DIFF
--- a/ph-httpclient/pom.xml
+++ b/ph-httpclient/pom.xml
@@ -69,10 +69,6 @@
       <version>${httpclient.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.helger.commons</groupId>
       <artifactId>ph-xml</artifactId>
       <optional>true</optional>


### PR DESCRIPTION
ph-httpclient and Apache HttpClient 5 use SLF4J directly, and the module has no Commons Logging references. Keeping jcl-over-slf4j adds duplicate org.apache.commons.logging classes for applications that already use Commons Logging 1.3.

Verified with:

`mvn -pl ph-httpclient -am verify`

All 63 ph-httpclient tests pass.